### PR TITLE
Fix: Block Editor hide-title checkbox resets on save with third-party meta boxes

### DIFF
--- a/classes/a3-hide-post-page-title-class.php
+++ b/classes/a3-hide-post-page-title-class.php
@@ -169,7 +169,7 @@ class Main
     {
         foreach ( self::supported_post_types() as $posttype )
         {
-            add_meta_box($this->a3hpt_slug, 'Hide Page and Post Title', array(
+            add_meta_box('a3-hide-post-page-title', 'Hide Page and Post Title', array(
                 $this,
                 'build_hptbox'
             ) , $posttype, 'side', 'default', array(
@@ -226,6 +226,11 @@ class Main
     /*Autosave metabox*/
     public function a3hpt_hptsave( $post_id, $post )
     {
+        // Block Editor saves via REST API; meta is managed by the sidebar panel.
+        if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+            return $post_id;
+        }
+
         if ((defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) || !isset($_REQUEST[$this->a3hpt_slug . '_noncename']) || !wp_verify_nonce($_REQUEST[$this->a3hpt_slug . '_noncename'], $this->a3hpt_slug . '_dononce'))
         {
             return $post_id;


### PR DESCRIPTION
## Summary

- Change `add_meta_box` ID from `_a3hpt_headertitle` (same as meta key) to `a3-hide-post-page-title` to prevent ID collision
- Revert `__back_compat_meta_box` back to `true` so the legacy meta box remains hidden in Block Editor
- Add `REST_REQUEST` guard to `a3hpt_hptsave` so the legacy save/delete logic is skipped entirely during Block Editor REST API saves

## Root Cause

When third-party plugins with back-compat meta boxes are active, their `save_post` hooks can trigger in a REST context. Without the `REST_REQUEST` guard, `a3hpt_hptsave` could reach `delete_post_meta` if `$_REQUEST` happened to carry the nonce but not the checkbox value, resetting the "hide title" setting to unchecked on every Block Editor save.

## Test Plan

- [ ] Check "Hide title" in Block Editor sidebar panel → save → reload → checkbox should remain checked
- [ ] Verify the legacy meta box does NOT appear as a second panel in Block Editor
- [ ] Verify Classic Editor still shows the legacy meta box and saves correctly
- [ ] Test with a third-party plugin that registers a back-compat meta box active

🤖 Generated with [Claude Code](https://claude.com/claude-code)